### PR TITLE
Fix warnings

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-INCLUDES = 
+AM_CPPFLAGS =
 SUBDIRS = src tests docs
 EXTRA_DIST = utils sql benchmarks config/bootstrap config/ac_mysql.m4
 

--- a/README
+++ b/README
@@ -2,7 +2,7 @@ Hi!
 
 This is the memcached mysql UDFs (user defined functions) to work with libmemcached, Brian Aker's super duper
 new fast client library for memcached.
-
+Original repo: https://github.com/smira/memcached_functions_mysql
 
 Prerequisites
 
@@ -24,15 +24,15 @@ library path for your server (and yes, we should fix this). On Linux you can
 set this by exporting the correct path in LD_LIBRARY_PATH for your mysql
 server.
 
-You can install the functions as listed below by cutting and pasting,or 
+You can install the functions as listed below by cutting and pasting,or
 optionally there now are two ways to install these easily:
 
 * sql/install_functions.sql - this loads the functions with simple CREATE FUNCTION
 commands as shown below
 
-* utils/install.pl - This is a perl script that queries your mysql.func table to see what 
-functions are already installed and installs them if not yet installed. It will ask you 
-each time for every function not installed, if you want to install, or you can run it with 
+* utils/install.pl - This is a perl script that queries your mysql.func table to see what
+functions are already installed and installs them if not yet installed. It will ask you
+each time for every function not installed, if you want to install, or you can run it with
 -s/--silent to have it not prompt you. It runs as the 'root' database user (required).
 
 memc_servers_add()
@@ -151,7 +151,7 @@ mysql> select memc_set('abc', 'cool new memcached udf in mysql');
 +----------------------------------------------------+
 | memc_set('abc', 'cool new memcached udf in mysql') |
 +----------------------------------------------------+
-|                                                  0 | 
+|                                                  0 |
 +----------------------------------------------------+
 1 row in set (0.00 sec)
 
@@ -162,7 +162,7 @@ mysql> select memc_get('abc');
 +---------------------------------+
 | memc_get('abc')                 |
 +---------------------------------+
-| cool new memcached udf in mysql | 
+| cool new memcached udf in mysql |
 +---------------------------------+
 1 row in set (0.00 sec)
 
@@ -173,7 +173,7 @@ mysql> select memc_delete('abc');
 +--------------------+
 | memc_delete('abc') |
 +--------------------+
-|                  0 | 
+|                  0 |
 +--------------------+
 1 row in set (0.00 sec)
 
@@ -181,7 +181,7 @@ mysql> select memc_get('abc');
 +-----------------+
 | memc_get('abc') |
 +-----------------+
-| NULL            | 
+| NULL            |
 +-----------------+
 1 row in set (0.00 sec)
 
@@ -192,7 +192,7 @@ mysql> select memc_set('abc', ' Spot ');
 +---------------------------+
 | memc_set('abc', ' Spot ') |
 +---------------------------+
-|                         0 | 
+|                         0 |
 +---------------------------+
 1 row in set (0.00 sec)
 
@@ -200,15 +200,15 @@ mysql> select memc_append('abc', ' run.');
 +-----------------------------+
 | memc_append('abc', ' run.') |
 +-----------------------------+
-|                           0 | 
+|                           0 |
 +-----------------------------+
 1 row in set (0.00 sec)
 
-mysql> select memc_get('abc');    
+mysql> select memc_get('abc');
 +-----------------+
 | memc_get('abc') |
 +-----------------+
-|  Spot  run.     | 
+|  Spot  run.     |
 +-----------------+
 1 row in set (0.00 sec)
 
@@ -216,7 +216,7 @@ mysql> select memc_prepend('abc', 'See');
 +----------------------------+
 | memc_prepend('abc', 'See') |
 +----------------------------+
-|                          0 | 
+|                          0 |
 +----------------------------+
 1 row in set (0.00 sec)
 
@@ -224,7 +224,7 @@ mysql> select memc_get('abc');
 +-----------------+
 | memc_get('abc') |
 +-----------------+
-| See Spot  run.  | 
+| See Spot  run.  |
 +-----------------+
 1 row in set (0.00 sec)
 
@@ -235,7 +235,7 @@ mysql> select memc_set('sequence:1', 1);
 +---------------------------+
 | memc_set('sequence:1', 1) |
 +---------------------------+
-|                         0 | 
+|                         0 |
 +---------------------------+
 1 row in set (0.00 sec)
 
@@ -243,7 +243,7 @@ mysql> select memc_get('sequence:1');
 +------------------------+
 | memc_get('sequence:1') |
 +------------------------+
-| 1                      | 
+| 1                      |
 +------------------------+
 1 row in set (0.00 sec)
 
@@ -251,7 +251,7 @@ mysql> select memc_increment('sequence:1', 5);
 +---------------------------------+
 | memc_increment('sequence:1', 5) |
 +---------------------------------+
-|                               6 | 
+|                               6 |
 +---------------------------------+
 1 row in set (0.00 sec)
 
@@ -259,7 +259,7 @@ mysql> select memc_increment('sequence:1', 10);
 ]+----------------------------------+
 | memc_increment('sequence:1', 10) |
 +----------------------------------+
-|                               16 | 
+|                               16 |
 +----------------------------------+
 1 row in set (0.01 sec)
 
@@ -267,7 +267,7 @@ mysql> select memc_increment('sequence:1');
 +------------------------------+
 | memc_increment('sequence:1') |
 +------------------------------+
-|                           17 | 
+|                           17 |
 +------------------------------+
 1 row in set (0.00 sec)
 
@@ -275,7 +275,7 @@ mysql> select memc_decrement('sequence:1');
 +------------------------------+
 | memc_decrement('sequence:1') |
 +------------------------------+
-|                           16 | 
+|                           16 |
 +------------------------------+
 1 row in set (0.00 sec)
 
@@ -283,7 +283,7 @@ mysql> select memc_decrement('sequence:1', 15);
 +----------------------------------+
 | memc_decrement('sequence:1', 15) |
 +----------------------------------+
-|                                1 | 
+|                                1 |
 +----------------------------------+
 1 row in set (0.00 sec)
 
@@ -294,7 +294,7 @@ mysql> select memc_replace('sequence:1', 'String value');
 +--------------------------------------------+
 | memc_replace('sequence:1', 'String value') |
 +--------------------------------------------+
-|                                          0 | 
+|                                          0 |
 +--------------------------------------------+
 1 row in set (0.00 sec)
 
@@ -302,7 +302,7 @@ mysql> select memc_get('sequence:1');
 +------------------------+
 | memc_get('sequence:1') |
 +------------------------+
-| String value           | 
+| String value           |
 +------------------------+
 1 row in set (0.01 sec)
 
@@ -317,7 +317,7 @@ You use this to set the type of behavior your client has to the memcached server
 
 mysql> select memc_list_behaviors()\G
 *************************** 1. row ***************************
-memc_list_behaviors(): 
+memc_list_behaviors():
 +-------------------------------------+
 | MEMCACHED SERVER BEHAVIORS          |
 +-------------------------------------+
@@ -335,14 +335,14 @@ mysql> select memc_servers_behavior_set('MEMCACHED_BEHAVIOR_TCP_NODELAY','1');
 +-----------------------------------------------------------------+
 | memc_servers_behavior_set('MEMCACHED_BEHAVIOR_TCP_NODELAY','1') |
 +-----------------------------------------------------------------+
-|                                                               0 | 
+|                                                               0 |
 +-----------------------------------------------------------------+
 1 row in set (0.01 sec)
 
 Have fun!
 
 Cheers,
-  Brian, 
-    Seattle, WA 
-  Patrick, 
+  Brian,
+    Seattle, WA
+  Patrick,
     Sharon, NH (Live Free or Die!).

--- a/config/ac_mysql.m4
+++ b/config/ac_mysql.m4
@@ -3,40 +3,40 @@ dnl Macro: MYSQL_CONFIG
 dnl ---------------------------------------------------------------------------
 AC_DEFUN([MYSQL_CONFIG_TEST], [
   AC_ARG_WITH(mysql,
-  [[  --with-mysql[=mysql_config]      
+  [[  --with-mysql[=mariadb_config]
                           Support for the MySQL.]],
   [
     if test -n "$withval"; then
       if test "$withval" = "yes"; then
-         AC_PATH_PROG([MYSQL_CONFIG], [mysql_config], "no", [$PATH:/usr/sbin:/usr/bin:/usr/local/bin:/usr/local/mysql/bin])
+         AC_PATH_PROG([MYSQL_CONFIG], [mariadb_config], "no", [$PATH:/usr/sbin:/usr/bin:/usr/local/bin:/usr/local/mysql/bin])
          if test "x$MYSQL_CONFIG" == "xno"; then
-           AC_MSG_ERROR(["could not find mysql_config"])
+           AC_MSG_ERROR(["could not find mariadb_config"])
          fi
       else
-        AC_MSG_CHECKING(for mysql_config)
+        AC_MSG_CHECKING(for mariadb_config)
         MYSQL_CONFIG="$withval"
         if test ! -f "$MYSQL_CONFIG"; then
-          AC_MSG_ERROR(["could not find mysql_config 2 : $MYSQL_CONFIG"])
+          AC_MSG_ERROR(["could not find mariadb_config 2 : $MYSQL_CONFIG"])
         fi
         AC_MSG_RESULT([$MYSQL_CONFIG])
       fi
     else
-      AC_PATH_PROG([MYSQL_CONFIG], [mysql_config], "no", [$PATH:/usr/sbin:/usr/bin:/usr/local/bin:/usr/local/mysql/bin])
+      AC_PATH_PROG([MYSQL_CONFIG], [mariadb_config], "no", [$PATH:/usr/sbin:/usr/bin:/usr/local/bin:/usr/local/mysql/bin])
       if test "x$MYSQL_CONFIG" == "xno"; then
-        AC_MSG_ERROR(["could not find mysql_config"])
+        AC_MSG_ERROR(["could not find mariadb_config"])
       fi
     fi
   ],
   [
-    AC_PATH_PROG([MYSQL_CONFIG], [mysql_config], "no", [$PATH])
+    AC_PATH_PROG([MYSQL_CONFIG], [mariadb_config], "no", [$PATH])
     if test "x$MYSQL_CONFIG" == "xno"; then
-      AC_MSG_ERROR(["could not find mysql_config"])
+      AC_MSG_ERROR(["could not find mariadb_config"])
     fi
   ])
-    
+
   AC_DEFINE([MYSQL_ENABLED], [1], [Enables MySQL])
   MYSQL_INC="`$MYSQL_CONFIG --cflags`"
-  MYSQL_LIB="`$MYSQL_CONFIG --libmysqld-libs`"
+  MYSQL_LIB="`$MYSQL_CONFIG --libs`"
 ])
 
 dnl ---------------------------------------------------------------------------

--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,9 @@ AC_CONFIG_HEADERS(src/libmemcached_config.h)
 AM_INIT_AUTOMAKE
 
 AC_PROG_CC
-AC_PROG_LIBTOOL
+#AC_PROG_LIBTOOL
+LT_INIT
+
 LIBTOOL="$LIBTOOL --preserve-dup-deps"
 AC_SUBST(LIBTOOL)dnl
 

--- a/configure.ac
+++ b/configure.ac
@@ -38,4 +38,5 @@ AC_TYPE_UINT16_T
 AC_TYPE_UINT64_T
 AC_PROG_CPP
 AC_PROG_CXX
-AC_OUTPUT(Makefile src/Makefile tests/Makefile docs/Makefile)
+AC_CONFIG_FILES([Makefile src/Makefile tests/Makefile docs/Makefile])
+AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -1,8 +1,8 @@
-AC_INIT(src/get.c)
-AC_CONFIG_AUX_DIR(config)
+AC_INIT([memcached_functions_mysql],[1.1])
+AC_CONFIG_SRCDIR([src/get.c])
 AM_CONFIG_HEADER(src/libmemcached_config.h)
 
-AM_INIT_AUTOMAKE("memcached_functions_mysql", 1.1 )
+AM_INIT_AUTOMAKE
 
 AC_PROG_CC
 AC_PROG_LIBTOOL

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_INIT([memcached_functions_mysql],[1.1])
 AC_CONFIG_SRCDIR([src/get.c])
-AM_CONFIG_HEADER(src/libmemcached_config.h)
+AC_CONFIG_HEADERS(src/libmemcached_config.h)
 
 AM_INIT_AUTOMAKE
 
@@ -25,4 +25,17 @@ AC_SUBST(DEPS_LIBS)
 AC_C_CONST
 AC_TYPE_SIZE_T
 AC_CHECK_HEADERS(limits.h syslimits.h)
+AC_CHECK_FUNCS([bzero])
+AC_CHECK_FUNCS([strcasecmp])
+AC_CHECK_FUNCS([strtol])
+AC_CHECK_HEADERS([strings.h])
+AC_CHECK_HEADERS([unistd.h])
+AC_CHECK_HEADER_STDBOOL
+AC_FUNC_MALLOC
+AC_FUNC_REALLOC
+AC_PROG_RANLIB
+AC_TYPE_UINT16_T
+AC_TYPE_UINT64_T
+AC_PROG_CPP
+AC_PROG_CXX
 AC_OUTPUT(Makefile src/Makefile tests/Makefile docs/Makefile)

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -1,4 +1,4 @@
-INCLUDES = include
+AM_CPPFLAGS = include
 
 EXTRA_DIST = memc_get.pod\
 	memc_set.pod\
@@ -37,59 +37,59 @@ man_MANS = memc_get.3\
 	memc_stat_get_keys.3\
 	memc_stats.3
 
-memc_get.3: memc_get.pod 
+memc_get.3: memc_get.pod
 	pod2man  -r "" -s 3 memc_get.pod > memc_get.3
-memc_get_by_key.3: memc_get.pod 
+memc_get_by_key.3: memc_get.pod
 	pod2man  -r "" -s 3 memc_get.pod > memc_get_by_key.3
-memc_add.3: memc_set.pod 
+memc_add.3: memc_set.pod
 	pod2man  -r "" -s 3 memc_set.pod > memc_add.3
-memc_replace.3: memc_set.pod 
+memc_replace.3: memc_set.pod
 	pod2man  -r "" -s 3 memc_set.pod > memc_replace.3
-memc_cas.3: memc_set.pod 
+memc_cas.3: memc_set.pod
 	pod2man  -r "" -s 3 memc_set.pod > memc_cas.3
-memc_cas_by_key.3: memc_set.pod 
+memc_cas_by_key.3: memc_set.pod
 	pod2man  -r "" -s 3 memc_set.pod > memc_cas_by_key.3
-memc_set.3: memc_set.pod 
+memc_set.3: memc_set.pod
 	pod2man  -r "" -s 3 memc_set.pod > memc_set.3
-memc_set_by_key.3: memc_set.pod 
+memc_set_by_key.3: memc_set.pod
 	pod2man  -r "" -s 3 memc_set.pod > memc_set_by_key.3
-memc_append.3: memc_append.pod 
+memc_append.3: memc_append.pod
 	pod2man  -r "" -s 3 memc_append.pod > memc_append.3
-memc_append_by_key.3: memc_append.pod 
+memc_append_by_key.3: memc_append.pod
 	pod2man  -r "" -s 3 memc_append.pod > memc_append_by_key.3
-memc_prepend.3: memc_prepend.pod 
+memc_prepend.3: memc_prepend.pod
 	pod2man  -r "" -s 3 memc_prepend.pod > memc_prepend.3
-memc_prepend_by_key.3: memc_prepend.pod 
+memc_prepend_by_key.3: memc_prepend.pod
 	pod2man  -r "" -s 3 memc_prepend.pod > memc_prepend_by_key.3
-memc_increment.3: memc_increment.pod 
+memc_increment.3: memc_increment.pod
 	pod2man  -r "" -s 3 memc_increment.pod > memc_increment.3
-memc_decrement.3: memc_decrement.pod 
+memc_decrement.3: memc_decrement.pod
 	pod2man  -r "" -s 3 memc_decrement.pod > memc_decrement.3
-memc_servers_set.3: memc_servers_set.pod 
+memc_servers_set.3: memc_servers_set.pod
 	pod2man  -r "" -s 3 memc_servers_set.pod > memc_servers_set.3
-memc_list_behaviors.3: memc_list_behaviors.pod 
+memc_list_behaviors.3: memc_list_behaviors.pod
 	pod2man  -r "" -s 3 memc_list_behaviors.pod > memc_list_behaviors.3
-memc_list_hash_types.3: memc_list_hash_types.pod 
+memc_list_hash_types.3: memc_list_hash_types.pod
 	pod2man  -r "" -s 3 memc_list_hash_types.pod > memc_list_hash_types.3
-memc_list_distribution_types.3: memc_list_distribution_types.pod 
+memc_list_distribution_types.3: memc_list_distribution_types.pod
 	pod2man  -r "" -s 3 memc_list_distribution_types.pod > memc_list_distribution_types.3
-memc_servers_behavior_set.3: memc_servers_behavior_set.pod 
+memc_servers_behavior_set.3: memc_servers_behavior_set.pod
 	pod2man  -r "" -s 3 memc_servers_behavior_set.pod > memc_servers_behavior_set.3
-memc_servers_behavior_get.3: memc_servers_behavior_get.pod 
+memc_servers_behavior_get.3: memc_servers_behavior_get.pod
 	pod2man  -r "" -s 3 memc_servers_behavior_get.pod > memc_servers_behavior_get.3
-memc_behavior_set.3: memc_behavior_set.pod 
+memc_behavior_set.3: memc_behavior_set.pod
 	pod2man  -r "" -s 3 memc_behavior_set.pod > memc_behavior_set.3
-memc_behavior_get.3: memc_behavior_get.pod 
+memc_behavior_get.3: memc_behavior_get.pod
 	pod2man  -r "" -s 3 memc_behavior_get.pod > memc_behavior_get.3
-memc_stats.3: memc_stats.pod 
+memc_stats.3: memc_stats.pod
 	pod2man  -r "" -s 3 memc_stats.pod > memc_stats.3
-memc_stat_get_keys.3: memc_stats.pod 
+memc_stat_get_keys.3: memc_stats.pod
 	pod2man  -r "" -s 3 memc_stats.pod > memc_stat_get_keys.3
-memc_stat_get_value.3: memc_stats.pod 
+memc_stat_get_value.3: memc_stats.pod
 	pod2man  -r "" -s 3 memc_stats.pod > memc_stat_get_value.3
-memc_udf_version.3: memc_stats.pod 
+memc_udf_version.3: memc_stats.pod
 	pod2man  -r "" -s 3 memc_stats.pod > memc_udf_version.3
-memc_libmemcached_version.3: memc_stats.pod 
+memc_libmemcached_version.3: memc_stats.pod
 	pod2man  -r "" -s 3 memc_stats.pod > memc_libmemcached_version.3
 
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,9 +1,8 @@
 EXTRA_DIST = common.h
-INCLUDES = -I$(top_builddir)/include $(MYSQL_INC)
+AM_CPPFLAGS = -I$(top_builddir)/include $(MYSQL_INC)
 
 lib_LTLIBRARIES = libmemcached_functions_mysql.la
 libmemcached_functions_mysql_la_SOURCES = util.c add.c get.c set.c prepend.c replace.c increment.c decrement.c append.c delete.c servers.c version.c stats.c get_cas.c
 libmemcached_functions_mysql_la_LDFLAGS = -module
 # had to add this back
 libmemcached_functions_mysql_la_LIBADD = $(DEPS_LIBS)
-

--- a/src/get.c
+++ b/src/get.c
@@ -8,6 +8,7 @@
 #include <string.h>
 
 #include <stdio.h>
+#include <err.h>
 
 #include <libmemcached/memcached.h>
 #include "common.h"

--- a/src/get.c
+++ b/src/get.c
@@ -65,7 +65,7 @@ char *memc_get(UDF_INIT *initid, UDF_ARGS *args,
 
   memc_function_st *container= (memc_function_st *)initid->ptr;
 
-  rc= memcached_mget(&container->memc, args->args, (size_t *)args->lengths, 1);
+  rc= memcached_mget(&container->memc, (const char * const *)args->args, (size_t *)args->lengths, 1);
 
   memcached_fetch_result(&container->memc, &container->results, &rc);
 
@@ -76,7 +76,7 @@ char *memc_get(UDF_INIT *initid, UDF_ARGS *args,
     *is_null= 1;
   }
 
-  return  memcached_result_value(&container->results);
+  return (char *)memcached_result_value(&container->results);
 }
 
 /* de-init UDF */
@@ -145,7 +145,7 @@ char *memc_get_by_key(UDF_INIT *initid, UDF_ARGS *args,
   rc= memcached_mget_by_key(&container->memc,
                               args->args[0],
                               (size_t )args->lengths[0],
-                              keys,
+                              (const char * const*)keys,
                               lengths,
                               args->arg_count - 1);
 
@@ -156,7 +156,7 @@ char *memc_get_by_key(UDF_INIT *initid, UDF_ARGS *args,
     *is_null= 1;
   }
 
-  return (memcached_result_value(&container->results));
+  return (char *)(memcached_result_value(&container->results));
 }
 
 /* de-init UDF */

--- a/src/get_cas.c
+++ b/src/get_cas.c
@@ -8,6 +8,7 @@
 #include <string.h>
 
 #include <stdio.h>
+#include <err.h>
 
 #include <libmemcached/memcached.h>
 #include "common.h"

--- a/src/servers.c
+++ b/src/servers.c
@@ -227,7 +227,7 @@ my_bool memc_servers_behavior_set_init(__attribute__ ((unused)) UDF_INIT *initid
   /*
     Do some checking of supplied behavior and setting
 
-    If a 1|0 value, check. Print error if not. We need some sort of 
+    If a 1|0 value, check. Print error if not. We need some sort of
     check for the other non 1|0 behaviors
   */
   if (! strcasecmp(args->args[0], "MEMCACHED_BEHAVIOR_SUPPORT_CAS") ||
@@ -422,11 +422,11 @@ long long memc_servers_behavior_set(__attribute__ ((unused)) UDF_INIT *initid,
   }
   else if (! strcasecmp(args->args[0], "MEMCACHED_BEHAVIOR_DISTRIBUTION"))
   {
-    if (! strcasecmp(args->args[1], "MEMCACHED_DISTRIBUTION_MODULA")) 
+    if (! strcasecmp(args->args[1], "MEMCACHED_DISTRIBUTION_MODULA"))
       setting= MEMCACHED_DISTRIBUTION_MODULA;
-    else if (! strcasecmp(args->args[1], "MEMCACHED_DISTRIBUTION_CONSISTENT")) 
+    else if (! strcasecmp(args->args[1], "MEMCACHED_DISTRIBUTION_CONSISTENT"))
       setting= MEMCACHED_DISTRIBUTION_CONSISTENT;
-    else if (! strcasecmp(args->args[1], "MEMCACHED_DISTRIBUTION_CONSISTENT_KETAMA")) 
+    else if (! strcasecmp(args->args[1], "MEMCACHED_DISTRIBUTION_CONSISTENT_KETAMA"))
       setting= MEMCACHED_DISTRIBUTION_CONSISTENT_KETAMA;
     else
       setting= MEMCACHED_DISTRIBUTION_MODULA;
@@ -609,7 +609,7 @@ char *memc_servers_behavior_get(__attribute__ ((unused)) UDF_INIT *initid,
   memcached_return rc;
   memcached_behavior behavior;
   uint64_t ivalue;
-  static char svalue[40];
+  static char svalue[41];
 
   if (! strcasecmp(args->args[0], "MEMCACHED_BEHAVIOR_SUPPORT_CAS"))
     behavior= MEMCACHED_BEHAVIOR_SUPPORT_CAS;
@@ -727,7 +727,7 @@ char *memc_servers_behavior_get(__attribute__ ((unused)) UDF_INIT *initid,
   }
   else
   {
-    sprintf(svalue, "%d", ivalue);
+    sprintf(svalue, "%ld", ivalue);
   }
   *length= strlen(svalue);
   return (char *)svalue;
@@ -928,5 +928,3 @@ int memc_get_servers(memcached_st *clone)
 
   return retval ;
 }
-
-

--- a/src/set.c
+++ b/src/set.c
@@ -93,7 +93,7 @@ my_bool memc_set_by_key_init(UDF_INIT *initid, UDF_ARGS *args, char *message)
   rc= memc_get_servers(&container->memc);
 
   initid->ptr= (char *)container;
-  fprintf(stderr, "1: container->expiration %d", container->expiration);
+  fprintf(stderr, "1: container->expiration %ld", container->expiration);
 
   return 0;
 }

--- a/src/stats.c
+++ b/src/stats.c
@@ -8,6 +8,7 @@
 #include <string.h>
 
 #include <stdio.h>
+#include <err.h>
 
 #include <libmemcached/memcached.h>
 #include "common.h"

--- a/src/stats.c
+++ b/src/stats.c
@@ -108,7 +108,7 @@ char *memc_stats(UDF_INIT *initid, UDF_ARGS *args,
     char **list;
     char **ptr;
     memcached_server_instance_st instance=
-        memcached_server_instance_by_position(&container->memc, x);
+        (memcached_server_instance_st) memcached_server_instance_by_position(&container->memc, x);
 
     list= memcached_stat_get_keys(&container->memc, &stat[x], &rc);
 

--- a/src/util.c
+++ b/src/util.c
@@ -90,10 +90,8 @@ memc_function_st *prepare_args(UDF_ARGS *args,
   if (args->arg_count < min_args || args->arg_count > max_args)
   {
     char msg_buf[200];
-    sprintf(msg_buf, "Usage: %s",
-            memc_error_msg(func), min_args);
-    fprintf(stderr, "Usage: %s",
-            memc_error_msg(func), min_args);
+    sprintf(msg_buf, "Usage: %s", memc_error_msg(func));
+    fprintf(stderr, "Usage: %s", memc_error_msg(func));
 
     strncpy(message, msg_buf, MYSQL_ERRMSG_SIZE);
     return (memc_function_st*)NULL;

--- a/src/util.c
+++ b/src/util.c
@@ -8,6 +8,7 @@
 #include <string.h>
 
 #include <stdio.h>
+#include <err.h>
 
 #include "common.h"
 

--- a/src/version.c
+++ b/src/version.c
@@ -10,6 +10,7 @@
 
 #include <stdio.h>
 #include <assert.h>
+#include <err.h>
 
 #include "common.h"
 #define BRIAN_LIKES_LOOP 1;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,6 +1,6 @@
-INCLUDES =
-LDADDS = 
-LIBS = 
+AM_CPPFLAGS =
+LDADDS =
+LIBS =
 
 EXTRA_DIST = memc_test.cmp memc_test.sql
 


### PR DESCRIPTION
Attempt to eliminate warnings and errors

Turn this 
```
AUTOCONF_VERSION=2.71 AUTOMAKE_VERSION=1.16 ./config/bootstrap  
./config/bootstrap: running `aclocal' 
./config/bootstrap: running `autoheader' 
./config/bootstrap: running `libtoolize --automake --copy --force' 
./config/bootstrap: running `automake --add-missing --copy --force' 
configure.ac:5: warning: AM_INIT_AUTOMAKE: two- and three-arguments forms are deprecated.  For more info, see:
configure.ac:5: https://www.gnu.org/software/automake/manual/automake.html#Modernize-AM_005fINIT_005fAUTOMAKE-invocation
configure.ac:7: installing 'config/compile'
configure.ac:8: installing 'config/config.guess'
configure.ac:8: installing 'config/config.sub'
configure.ac:5: installing 'config/install-sh'
configure.ac:5: installing 'config/missing'
Makefile.am:1: warning: 'INCLUDES' is the old name for 'AM_CPPFLAGS' (or '*_CPPFLAGS')
docs/Makefile.am:1: warning: 'INCLUDES' is the old name for 'AM_CPPFLAGS' (or '*_CPPFLAGS')
src/Makefile.am:2: warning: 'INCLUDES' is the old name for 'AM_CPPFLAGS' (or '*_CPPFLAGS')
src/Makefile.am: installing 'config/depcomp'
tests/Makefile.am:1: warning: 'INCLUDES' is the old name for 'AM_CPPFLAGS' (or '*_CPPFLAGS')
./config/bootstrap: running `autoconf' 
configure.ac:3: warning: 'AM_CONFIG_HEADER': this macro is obsolete.
configure.ac:3: You should use the 'AC_CONFIG_HEADERS' macro instead.
/usr/local/share/autoconf-2.71/autoconf/general.m4:2434: AC_DIAGNOSE is expanded from...
aclocal.m4:9318: AM_CONFIG_HEADER is expanded from...
configure.ac:3: the top level
configure.ac:5: warning: AM_INIT_AUTOMAKE: two- and three-arguments forms are deprecated.
/usr/local/share/autoconf-2.71/autoconf/general.m4:2434: AC_DIAGNOSE is expanded from...
aclocal.m4:9158: AM_INIT_AUTOMAKE is expanded from...
configure.ac:5: the top level
configure.ac:8: warning: The macro `AC_PROG_LIBTOOL' is obsolete.
configure.ac:8: You should run autoupdate.
aclocal.m4:129: AC_PROG_LIBTOOL is expanded from...
configure.ac:8: the top level
configure.ac:28: warning: AC_OUTPUT should be used without arguments.
configure.ac:28: You should run autoupdate.
```

into this
```
./config/bootstrap: running `aclocal' 
./config/bootstrap: running `autoheader' 
./config/bootstrap: running `libtoolize --automake --copy --force' 
./config/bootstrap: running `automake --add-missing --copy --force' 
./config/bootstrap: running `autoconf' 
```

Also eliminate compilation warnings for type casting, missing headers and an off-by-one